### PR TITLE
fix(ds-input): åpne tastatur på FØRSTE trykk + rull fokusert felt over tastaturet

### DIFF
--- a/lib/src/components/input/ds_input.dart
+++ b/lib/src/components/input/ds_input.dart
@@ -106,6 +106,31 @@ class _DsInputState extends State<DsInput> {
 
   void _onFocusChange() {
     setState(() => _isFocused = _focusNode.hasFocus);
+    if (_focusNode.hasFocus) _ensureVisibleAboveKeyboard();
+  }
+
+  /// Scrolls the focused field above the soft keyboard so the user can see
+  /// what they are typing. No-op when the field is not inside a [Scrollable]
+  /// (keyboard avoidance is then left to Scaffold.resizeToAvoidBottomInset).
+  ///
+  /// Runs one extra frame after focus so it targets the post-keyboard
+  /// (shrunken) viewport instead of racing EditableText's own caret reveal;
+  /// it converges to the same end state, so the two do not oscillate.
+  void _ensureVisibleAboveKeyboard() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_focusNode.hasFocus) return;
+      if (Scrollable.maybeOf(context) == null) return;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted || !_focusNode.hasFocus || !context.mounted) return;
+        Scrollable.ensureVisible(
+          context,
+          alignment: 0.1, // small margin above the keyboard
+          duration: const Duration(milliseconds: 150),
+          curve: Curves.easeOut,
+          alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
+        );
+      });
+    });
   }
 
   @override
@@ -202,7 +227,19 @@ class _DsInputState extends State<DsInput> {
               (_, {required currentLength, required isFocused, maxLength}) =>
                   null,
           expands: false,
-          decoration: InputDecoration.collapsed(
+          // contentPadding lives INSIDE the TextField (not an outer Padding)
+          // so the field's own hit-test area covers the whole control — a tap
+          // anywhere opens the keyboard on the FIRST tap. isCollapsed keeps the
+          // tight vertical metrics of the previous InputDecoration.collapsed.
+          decoration: InputDecoration(
+            isCollapsed: true,
+            filled: false,
+            border: InputBorder.none,
+            enabledBorder: InputBorder.none,
+            focusedBorder: InputBorder.none,
+            disabledBorder: InputBorder.none,
+            errorBorder: InputBorder.none,
+            contentPadding: padding,
             hintText: widget.placeholder,
             hintStyle: textStyle.copyWith(color: colorScale.textSubtle),
           ),
@@ -222,53 +259,66 @@ class _DsInputState extends State<DsInput> {
       );
     }
 
-    Widget result = GestureDetector(
-      onTap: () {
-        if (!widget.disabled && !widget.readOnly) {
-          _focusNode.requestFocus();
-        }
-      },
-      behavior: HitTestBehavior.opaque,
-      child: AnimatedContainer(
-        duration: duration,
-        decoration: BoxDecoration(
-          color: widget.readOnly
-              ? colorScale.surfaceDefault
-              : colorScale.backgroundDefault,
-          borderRadius: radius,
-          border: Border.fromBorderSide(borderSide),
-        ),
-        child: Row(
-          children: [
-            if (widget.prefix != null) ...[
-              Padding(
+    final canFocusByTap = !widget.disabled && !widget.readOnly;
+
+    // No tap handler wraps the whole field: the TextField now hit-tests its
+    // entire area (contentPadding above), so it wins the gesture and opens the
+    // keyboard on the FIRST tap. A competing ancestor GestureDetector/Listener
+    // would steal that first tap — the double-tap-to-open-keyboard bug.
+    Widget result = AnimatedContainer(
+      duration: duration,
+      decoration: BoxDecoration(
+        color: widget.readOnly
+            ? colorScale.surfaceDefault
+            : colorScale.backgroundDefault,
+        borderRadius: radius,
+        border: Border.fromBorderSide(borderSide),
+      ),
+      child: Row(
+        children: [
+          if (widget.prefix != null) ...[
+            // Translucent (not opaque): a tap on the prefix gutter focuses the
+            // field, but an interactive prefix child still handles its own tap.
+            GestureDetector(
+              behavior: HitTestBehavior.translucent,
+              onTap: canFocusByTap ? _focusNode.requestFocus : null,
+              child: Padding(
                 padding: const EdgeInsets.only(left: 8),
                 child: widget.prefix!,
               ),
-            ],
-            Expanded(
-              child: Padding(padding: padding, child: textFieldTree),
             ),
-            if (widget.suffix != null) ...[
-              Padding(
+          ],
+          Expanded(child: textFieldTree),
+          if (widget.suffix != null) ...[
+            GestureDetector(
+              behavior: HitTestBehavior.translucent,
+              onTap: canFocusByTap ? _focusNode.requestFocus : null,
+              child: Padding(
                 padding: const EdgeInsets.only(right: 8),
                 child: widget.suffix!,
               ),
-            ],
+            ),
           ],
-        ),
+        ],
       ),
     );
 
-    if (_isFocused && !widget.disabled && !widget.readOnly) {
-      result = DecoratedBox(
-        decoration: DsFocus.focusRingWithRadius(colorScale, radius),
-        child: Padding(
-          padding: const EdgeInsets.all(DsFocus.ringWidth),
-          child: result,
-        ),
-      );
-    }
+    // The focus-ring wrapper is ALWAYS in the tree (its space is always
+    // reserved); only its decoration toggles. Inserting/removing the
+    // DecoratedBox+Padding on focus would change the widget type under the
+    // MouseRegion, tearing down and recreating the TextField element — which
+    // kills the in-flight first-tap keyboard open (the double-tap bug). Keeping
+    // the structure constant also removes the 3px layout jump on focus.
+    final showFocusRing = _isFocused && !widget.disabled && !widget.readOnly;
+    result = DecoratedBox(
+      decoration: showFocusRing
+          ? DsFocus.focusRingWithRadius(colorScale, radius)
+          : const BoxDecoration(),
+      child: Padding(
+        padding: const EdgeInsets.all(DsFocus.ringWidth),
+        child: result,
+      ),
+    );
 
     if (widget.disabled) {
       result = IgnorePointer(

--- a/test/components/ds_input_test.dart
+++ b/test/components/ds_input_test.dart
@@ -1,0 +1,96 @@
+import 'package:designsystemet_flutter/designsystemet_flutter.dart';
+import 'package:designsystemet_flutter/generated/ds_theme_digdir.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Widget _host(Widget child) => DsTheme(
+  data: DsThemeDigdir.light(),
+  child: MaterialApp(
+    home: Scaffold(
+      body: Center(child: SizedBox(width: 300, child: child)),
+    ),
+  ),
+);
+
+void main() {
+  group('DsInput single-tap keyboard', () {
+    // Regression for the double-tap-to-open-keyboard bug: a single tap must
+    // both focus the field AND open the platform input connection (keyboard).
+    testWidgets('opens the keyboard on the FIRST tap', (tester) async {
+      final focus = FocusNode();
+      addTearDown(focus.dispose);
+      await tester.pumpWidget(
+        _host(DsInput(focusNode: focus, size: DsSize.md, placeholder: 'Skriv')),
+      );
+
+      expect(tester.testTextInput.hasAnyClients, isFalse);
+
+      await tester.tap(find.byType(DsInput));
+      await tester.pump();
+
+      expect(focus.hasFocus, isTrue, reason: 'one tap must focus the field');
+      expect(
+        tester.testTextInput.hasAnyClients,
+        isTrue,
+        reason: 'the soft keyboard must open after a single tap',
+      );
+    });
+
+    // A tap inside the content padding (near the field edge) used to land on
+    // the external Padding — OUTSIDE the TextField hit area — so it only
+    // requested focus without opening the keyboard. It must now open it.
+    testWidgets('a tap near the field edge still opens the keyboard', (
+      tester,
+    ) async {
+      final focus = FocusNode();
+      addTearDown(focus.dispose);
+      await tester.pumpWidget(
+        _host(DsInput(focusNode: focus, size: DsSize.md)),
+      );
+
+      // Tap inside the content padding (past the 3px focus-ring gutter, within
+      // the field's contentPadding) — where the old EXTERNAL Padding put the
+      // tap outside the TextField hit area and only requested focus.
+      final rect = tester.getRect(find.byType(DsInput));
+      await tester.tapAt(Offset(rect.left + 8, rect.center.dy));
+      await tester.pump();
+
+      expect(tester.testTextInput.hasAnyClients, isTrue);
+    });
+
+    testWidgets('tapping the prefix focuses the field', (tester) async {
+      final focus = FocusNode();
+      addTearDown(focus.dispose);
+      await tester.pumpWidget(
+        _host(
+          DsInput(
+            focusNode: focus,
+            size: DsSize.md,
+            prefix: const Icon(Icons.search),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.search));
+      await tester.pumpAndSettle();
+
+      expect(focus.hasFocus, isTrue);
+    });
+
+    testWidgets('disabled field does not focus or open the keyboard', (
+      tester,
+    ) async {
+      final focus = FocusNode();
+      addTearDown(focus.dispose);
+      await tester.pumpWidget(
+        _host(DsInput(focusNode: focus, size: DsSize.md, disabled: true)),
+      );
+
+      await tester.tap(find.byType(DsInput), warnIfMissed: false);
+      await tester.pumpAndSettle();
+
+      expect(focus.hasFocus, isFalse);
+      expect(tester.testTextInput.hasAnyClients, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Sammendrag

Retter to UX-feil som rammet **alle** `DsTextfield`/`DsTextarea`/`DsSearch` (alle bygger på `DsInput`).

### 1. Måtte dobbeltklikke for å få opp tastaturet
Rotårsak (todelt):
- en **ugjennomsiktig ytre `GestureDetector(onTap: requestFocus)`** omsluttet hele feltet og vant gesture-arenaen, så `TextField` sin egen førstetrykks-`requestKeyboard` ble slått ut, og
- fokus-ringen (`DecoratedBox`+`Padding`) ble satt inn **kun ved fokus**, noe som endret widget-typen under `MouseRegion` og rev ned/gjenskapte `TextField`-elementet midt i trykket — drepte tastatur-åpningen på første trykk. Andre trykk (allerede fokusert, stabilt tre) virket.
- innholds-paddingen lå i en **ekstern `Padding`**, så trykk på padding-sonen aldri nådde `TextField` sitt treff-område.

**Fiks:** flytt padding inn i `InputDecoration.contentPadding` (feltet treff-tester hele arealet), fjern ekstern `Padding`, fjern den ytre tap-handleren, og gjør fokus-ring-wrapperen **strukturelt konstant** (alltid til stede, bytter kun dekorasjon — fjerner også 3px-hopp ved fokus). Prefiks/suffiks tap-til-fokus bevart via en **gjennomsiktig** `GestureDetector` (interaktive barn håndterer fortsatt egne trykk).

### 2. Fokusert felt skjult bak tastaturet
La til en guardet **`ensureVisible`-ved-fokus** som ruller feltet opp over tastaturet når det ligger i en `Scrollable` (no-op ellers; utsatt én frame så den treffer viewport-en etter at tastaturet har dyttet opp, og konvergerer med `EditableText` sin egen caret-on-screen i stedet for å slåss mot den).

## Test
- Ny `test/components/ds_input_test.dart`: ett trykk åpner plattform-input-koblingen (også trykk i innholds-paddingen) + bevarer fokus/disabled-oppførsel.
- Full pakke-suite grønn (181 tester). `flutter analyze` rent på endrede filer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
