### PR TITLE
Release 0.3.0 (stabil)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Endringslogg
 
-## 0.3.0-beta.1 — 2026-06-06
+## 0.3.0 — 2026-06-06
 
 Stor paritetsoppdatering mot Designsystemet (React-referanse v1.15.0). Standardtemaet
 bruker mørkeblå `#003087` som accent-base (WCAG 2.1 AA, verifisert med ny
-kontrasttest).
+kontrasttest). (Først utgitt som forhåndsutgivelse `0.3.0-beta.1`.)
 
 ### Brytende endringer
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,6 @@
 
 > **[Les dokumentasjonen](https://stigvaage.github.io/designsystemet-flutter/)** | **[Interaktiv komponentkatalog (Widgetbook)](https://stigvaage.github.io/designsystemet-flutter/widgetbook/)**
 
-> [!WARNING]
-> **Betaversjon (`0.3.0-beta.1`).** Dette er en forhåndsutgivelse for testing. API-et kan fortsatt endres før `0.3.0` stabil. Tilbakemeldinger og feilrapporter mottas gjerne.
-
 Flutter-implementasjon av [Designsystemet](https://designsystemet.no) -- det norske offentlige designsystemet utviklet av Digitaliseringsdirektoratet (Digdir). Biblioteket gir norske offentlige virksomheter og andre organisasjoner et ferdig sett med tilgjengelige, tokendrevne UI-komponenter som følger det offisielle designsystemet -- uten avhengigheter til Material eller Cupertino.
 
 ## Funksjoner
@@ -37,7 +34,7 @@ Legg til pakken i din `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  designsystemet_flutter: ^0.3.0-beta.1
+  designsystemet_flutter: ^0.3.0
 ```
 
 Kjør deretter:
@@ -46,9 +43,7 @@ Kjør deretter:
 flutter pub get
 ```
 
-> **Merk:** `0.3.0-beta.1` er en forhåndsutgivelse og må spesifiseres eksplisitt som over — `flutter pub add designsystemet_flutter` velger ellers siste stabile utgave (`0.2.x`).
-
-## Hva er nytt i 0.3.0-beta.1
+## Hva er nytt i 0.3.0
 
 - **Material-fritt tekstfelt** — `DsInput` (og dermed Textfield/Textarea/Search/Suggestion/Select) er reimplementert på `EditableText`. Hele biblioteket er nå fullstendig fritt for Material/Cupertino.
 - **Offisiell typografi-skala** — font-størrelsene følger nå Designsystemets primitiv-tokens nøyaktig (overskrift og brødtekst).

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stigvaage/designsystemet-flutter-mcp",
-  "version": "0.3.0-beta.1",
+  "version": "0.3.0",
   "description": "MCP-server for designsystemet-flutter — komponent-API, migrering og dokumentasjonssøk",
   "type": "module",
   "main": "dist/index.js",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: designsystemet_flutter
 description: Uoffisiell Flutter-implementasjon av Designsystemet (designsystemet.no) fra Digitaliseringsdirektoratet.
-version: 0.3.0-beta.1
+version: 0.3.0
 homepage: https://stigvaage.github.io/designsystemet-flutter/
 repository: https://github.com/stigvaage/designsystemet-flutter
 topics:


### PR DESCRIPTION
Klargjør stabil **0.3.0** (oppgradering fra 0.3.0-beta.1).

## Endringer
- Versjon `0.3.0-beta.1` → **`0.3.0`** i `pubspec.yaml` og `mcp-server/package.json`.
- `CHANGELOG.md`: 0.3.0-overskrift (datert 2026-06-06), notert at den først ble utgitt som forhåndsutgivelse `0.3.0-beta.1`.
- `README.md`: fjernet beta-merknad, install `^0.3.0`, «Hva er nytt i 0.3.0».

## Grønt
analyze 0 · 658 tester · format rent · MCP 16 tester + 0 sårbarheter · site bygger · `flutter pub publish --dry-run` = **0 advarsler**.

## Etter merge (utgivelsesflyt)
1. Du: `flutter pub publish` → publiserer **0.3.0 stabil** til pub.dev (blir «latest» der).
2. Jeg: oppretter GitHub Release `v0.3.0` (ordinær release, ikke pre-release) → publiserer MCP `0.3.0` til GitHub Packages med `latest`-tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)