### PR TITLE
fix(dialog): wrap DsDialog title in Flexible (prevent header overflow)

### DIFF
--- a/lib/src/components/dialog/ds_dialog.dart
+++ b/lib/src/components/dialog/ds_dialog.dart
@@ -208,11 +208,16 @@ class _DsDialogState extends State<DsDialog> {
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
                       if (widget.title != null)
-                        DefaultTextStyle(
-                          style: theme.typography.headingMd.copyWith(
-                            color: colorScale.textDefault,
+                        // Flexible so a long title shrinks/wraps within the
+                        // header Row instead of overflowing it (the close
+                        // button keeps its size via spaceBetween).
+                        Flexible(
+                          child: DefaultTextStyle(
+                            style: theme.typography.headingMd.copyWith(
+                              color: colorScale.textDefault,
+                            ),
+                            child: widget.title!,
                           ),
-                          child: widget.title!,
                         ),
                       if (widget.closeButton)
                         _DsDialogCloseButton(


### PR DESCRIPTION
## Problem
`DsDialog` lays out its header as a `spaceBetween` `Row` of `[title, closeButton]`, but the title slot is **unflexed**. A long title (e.g. «Avbryt verifisering?») exceeds the available width at narrow dialog sizes and throws a `RenderFlex overflowed` in debug/widget tests (and clips in release).

This surfaced as 3 failing `app_bar_factory` tests in the Samlepunktet app.

## Fix
Wrap the title's `DefaultTextStyle` in `Flexible`, so a long title shrinks/wraps within the row instead of overflowing. Short titles are unaffected (Flexible only constrains when needed); the close button keeps its intrinsic size.

## Test
- `flutter analyze lib/src/components/dialog` → No issues found
- `flutter test test/components/ds_dialog_test.dart` → all pass (16/16)
- Downstream: the app's `app_bar_factory_test.dart` (which opens the abort-confirmation dialog) now passes (11/11) against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)